### PR TITLE
Fix potion sorting by real ingredient count

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -532,7 +532,12 @@ impl App {
                 }
             })
             .sorted_by(|potion_a, potion_b| {
-                potion_a.ingredients.len().cmp(&potion_b.ingredients.len())
+                potion_a
+                    .ingredients
+                    .iter()
+                    .flatten()
+                    .count()
+                    .cmp(&potion_b.ingredients.iter().flatten().count())
             })
             .cloned()
             .collect();


### PR DESCRIPTION
## Summary
- fix sorting in `generate_potions` so potions are ordered by actual ingredient count

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683f9fdaf174832e90ffb2d28aef76e0